### PR TITLE
Fix OpenCashDrawer

### DIFF
--- a/ESCPOS_NET.ConsoleTest/TestCashDrawer.cs
+++ b/ESCPOS_NET.ConsoleTest/TestCashDrawer.cs
@@ -1,4 +1,4 @@
-﻿using ESCPOS_NET.Emitters;
+using ESCPOS_NET.Emitters;
 using ESCPOS_NET.Utilities;
 
 namespace ESCPOS_NET.ConsoleTest
@@ -6,12 +6,10 @@ namespace ESCPOS_NET.ConsoleTest
     public static partial class Tests
     {
         public static byte[][] CashDrawerOpenPin2(ICommandEmitter e) => new byte[][] {
-            e.CashDrawerOpenPin2(), // Fire this twice ensures it's operation 
             e.CashDrawerOpenPin2()
         };
 
         public static byte[][] CashDrawerOpenPin5(ICommandEmitter e) => new byte[][] {
-            e.CashDrawerOpenPin5(), // Fire this twice ensures it's operation 
             e.CashDrawerOpenPin5()
         };
     }

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/CashDrawerCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/CashDrawerCommands.cs
@@ -1,12 +1,16 @@
-﻿using ESCPOS_NET.Emitters.BaseCommandValues;
+using ESCPOS_NET.Emitters.BaseCommandValues;
 
 namespace ESCPOS_NET.Emitters
 {
     public abstract partial class BaseCommandEmitter : ICommandEmitter
     {
         /* Cash Drawer Commands */
-        public virtual byte[] CashDrawerOpenPin2() => new byte[] { Cmd.ESC, Ops.CashDrawerPulse, 0x00 };
+        public virtual byte[] CashDrawerOpenPin2(int pulseOnTimeMs = 120, int pulseOffTimeMs = 240) {
+            return new byte[] { Cmd.ESC, Ops.CashDrawerPulse, 0x00, (byte) (pulseOnTimeMs / 2), (byte) (pulseOffTimeMs / 2) };
+        }
 
-        public virtual byte[] CashDrawerOpenPin5() => new byte[] { Cmd.ESC, Ops.CashDrawerPulse, 0x01 };
+        public virtual byte[] CashDrawerOpenPin5(int pulseOnTimeMs = 120, int pulseOffTimeMs = 240) {
+            return new byte[] { Cmd.ESC, Ops.CashDrawerPulse, 0x01, (byte) (pulseOnTimeMs / 2), (byte) (pulseOffTimeMs / 2) };
+        }
     }
 }

--- a/ESCPOS_NET/Emitters/ICommandEmitter.cs
+++ b/ESCPOS_NET/Emitters/ICommandEmitter.cs
@@ -1,4 +1,4 @@
-﻿namespace ESCPOS_NET.Emitters
+namespace ESCPOS_NET.Emitters
 {
     public interface ICommandEmitter
     {
@@ -26,9 +26,9 @@
         byte[] Disable();
 
         /* Cash Drawer Commands */
-        byte[] CashDrawerOpenPin2();
+        byte[] CashDrawerOpenPin2(int pulseOnTimeMs = 120, int pulseOffTimeMs = 240);
 
-        byte[] CashDrawerOpenPin5();
+        byte[] CashDrawerOpenPin5(int pulseOnTimeMs = 120, int pulseOffTimeMs = 240);
 
         /* Character Commands */
         byte[] SetStyles(PrintStyle style);


### PR DESCRIPTION
Added missing ON and OFF times in `OpenCashDrawerPin2()` and `OpenCashDrawerPin5` (see https://www.epson-biz.com/modules/ref_escpos/index.php?content_id=195)